### PR TITLE
Cosmetic polish for natspec, comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "author": "Aragon Assocation <legal@aragon.org>",
-  "license": "(GPL-3.0-or-later OR MIT)",
+  "license": "GPL-3.0-or-later",
   "devDependencies": {
     "lerna": "^3.14.1"
   },

--- a/packages/protocol/contracts/Staking.sol
+++ b/packages/protocol/contracts/Staking.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.5.17;
 
+import "./lib/Checkpointing.sol";
+import "./lib/os/IsContract.sol";
 import "./lib/os/SafeMath.sol";
 import "./lib/os/SafeERC20.sol";
-import "./lib/os/IsContract.sol";
 import "./lib/os/TimeHelpers.sol";
-import "./lib/Checkpointing.sol";
 
 import "./locking/ILockable.sol";
 import "./locking/ILockManager.sol";
@@ -15,9 +15,9 @@ import "./standards/IApproveAndCallFallBack.sol";
 
 
 contract Staking is IERC900, IERC900History, ILockable, IApproveAndCallFallBack, IsContract, TimeHelpers {
-    using SafeMath for uint256;
     using Checkpointing for Checkpointing.History;
     using SafeERC20 for IERC20;
+    using SafeMath for uint256;
 
     uint256 private constant MAX_UINT64 = uint256(uint64(-1));
 

--- a/packages/protocol/contracts/Staking.sol
+++ b/packages/protocol/contracts/Staking.sol
@@ -326,13 +326,13 @@ contract Staking is IERC900, IERC900History, ILockable, IApproveAndCallFallBack,
         external
         view
         returns (
-            uint256 _amount,
-            uint256 _allowance
+            uint256 amount,
+            uint256 allowance
         )
     {
         Lock storage lock_ = accounts[_user].locks[_lockManager];
-        _amount = lock_.amount;
-        _allowance = lock_.allowance;
+        amount = lock_.amount;
+        allowance = lock_.allowance;
     }
 
     /**

--- a/packages/protocol/contracts/Staking.sol
+++ b/packages/protocol/contracts/Staking.sol
@@ -109,70 +109,6 @@ contract Staking is IERC900, IERC900History, ILockable, IApproveAndCallFallBack,
     }
 
     /**
-     * @notice Transfer `@tokenAmount(self.token(): address, _amount)` to `_to`’s staked balance
-     * @dev Callable only by a user
-     * @param _to Recipient
-     * @param _amount Amount of tokens to be transferred
-     */
-    function transfer(address _to, uint256 _amount) external {
-        _transfer(msg.sender, _to, _amount);
-    }
-
-    /**
-     * @notice Transfer `@tokenAmount(self.token(): address, _amount)` directly to `_to`’s balance
-     * @dev Callable only by a user
-     * @param _to Recipient
-     * @param _amount Amount of tokens to be transferred
-     */
-    function transferAndUnstake(address _to, uint256 _amount) external {
-        _transferAndUnstake(msg.sender, _to, _amount);
-    }
-
-    /**
-     * @notice Slash `@tokenAmount(self.token(): address, _amount)` from `_from`'s locked balance to `_to`'s staked balance
-     * @dev Callable only by a lock manager
-     * @param _from Owner of the locked tokens
-     * @param _to Recipient
-     * @param _amount Amount of tokens to be transferred via slashing
-     */
-    function slash(address _from, address _to, uint256 _amount) external {
-        _unlockUnsafe(_from, msg.sender, _amount);
-        _transfer(_from, _to, _amount);
-    }
-
-    /**
-     * @notice Slash `@tokenAmount(self.token(): address, _amount)` from `_from`'s locked balance  directly to `_to`'s balance
-     * @dev Callable only by a lock manager
-     * @param _from Owner of the locked tokens
-     * @param _to Recipient
-     * @param _amount Amount of tokens to be transferred via slashing
-     */
-    function slashAndUnstake(address _from, address _to, uint256 _amount) external {
-        _unlockUnsafe(_from, msg.sender, _amount);
-        _transferAndUnstake(_from, _to, _amount);
-    }
-
-    /**
-     * @notice Slash `@tokenAmount(self.token(): address, _slashAmount)` from `_from`'s locked balance to `_to`'s staked balance, and leave an additional `@tokenAmount(self.token(): address, _unlockAmount)` unlocked for `_from`
-     * @dev Callable only by a lock manager
-     * @param _from Owner of the locked tokens
-     * @param _to Recipient
-     * @param _unlockAmount Amount of tokens to be left unlocked
-     * @param _slashAmount Amount of tokens to be transferred via slashing
-     */
-    function slashAndUnlock(
-        address _from,
-        address _to,
-        uint256 _unlockAmount,
-        uint256 _slashAmount
-    )
-        external
-    {
-        _unlockUnsafe(_from, msg.sender, _unlockAmount.add(_slashAmount));
-        _transfer(_from, _to, _slashAmount);
-    }
-
-    /**
      * @notice Increase allowance of lock manager `_lockManager` by `@tokenAmount(self.token(): address, _allowance)`
      * @dev Callable only by a user
      * @param _lockManager Lock manager
@@ -271,6 +207,70 @@ contract Staking is IERC900, IERC900History, ILockable, IApproveAndCallFallBack,
         emit LockManagerRemoved(_user, _lockManager);
 
         delete account.locks[_lockManager];
+    }
+
+    /**
+     * @notice Slash `@tokenAmount(self.token(): address, _amount)` from `_from`'s locked balance to `_to`'s staked balance
+     * @dev Callable only by a lock manager
+     * @param _from Owner of the locked tokens
+     * @param _to Recipient
+     * @param _amount Amount of tokens to be transferred via slashing
+     */
+    function slash(address _from, address _to, uint256 _amount) external {
+        _unlockUnsafe(_from, msg.sender, _amount);
+        _transfer(_from, _to, _amount);
+    }
+
+    /**
+     * @notice Slash `@tokenAmount(self.token(): address, _amount)` from `_from`'s locked balance  directly to `_to`'s balance
+     * @dev Callable only by a lock manager
+     * @param _from Owner of the locked tokens
+     * @param _to Recipient
+     * @param _amount Amount of tokens to be transferred via slashing
+     */
+    function slashAndUnstake(address _from, address _to, uint256 _amount) external {
+        _unlockUnsafe(_from, msg.sender, _amount);
+        _transferAndUnstake(_from, _to, _amount);
+    }
+
+    /**
+     * @notice Slash `@tokenAmount(self.token(): address, _slashAmount)` from `_from`'s locked balance to `_to`'s staked balance, and leave an additional `@tokenAmount(self.token(): address, _unlockAmount)` unlocked for `_from`
+     * @dev Callable only by a lock manager
+     * @param _from Owner of the locked tokens
+     * @param _to Recipient
+     * @param _unlockAmount Amount of tokens to be left unlocked
+     * @param _slashAmount Amount of tokens to be transferred via slashing
+     */
+    function slashAndUnlock(
+        address _from,
+        address _to,
+        uint256 _unlockAmount,
+        uint256 _slashAmount
+    )
+        external
+    {
+        _unlockUnsafe(_from, msg.sender, _unlockAmount.add(_slashAmount));
+        _transfer(_from, _to, _slashAmount);
+    }
+
+    /**
+     * @notice Transfer `@tokenAmount(self.token(): address, _amount)` to `_to`’s staked balance
+     * @dev Callable only by a user
+     * @param _to Recipient
+     * @param _amount Amount of tokens to be transferred
+     */
+    function transfer(address _to, uint256 _amount) external {
+        _transfer(msg.sender, _to, _amount);
+    }
+
+    /**
+     * @notice Transfer `@tokenAmount(self.token(): address, _amount)` directly to `_to`’s balance
+     * @dev Callable only by a user
+     * @param _to Recipient
+     * @param _amount Amount of tokens to be transferred
+     */
+    function transferAndUnstake(address _to, uint256 _amount) external {
+        _transferAndUnstake(msg.sender, _to, _amount);
     }
 
     /**

--- a/packages/protocol/contracts/lib/Checkpointing.sol
+++ b/packages/protocol/contracts/lib/Checkpointing.sol
@@ -112,7 +112,7 @@ library Checkpointing {
     }
 
     /**
-     * @dev Private function execute a binary search to find the most recent registered past value of a history based on
+     * @dev Private function to execute a binary search to find the most recent registered past value of a history based on
      *      a given point in time. It will return zero if there is no registered value or if given time is previous to
      *      the first registered value. Note that this function will be more suitable when don't know how recent the
      *      time used to index may be.

--- a/packages/protocol/contracts/locking/ILockManager.sol
+++ b/packages/protocol/contracts/locking/ILockManager.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.5.17;
 
 interface ILockManager {
     /**
-     * @notice Check if `_user`'s by `_lockManager` can be unlocked
+     * @notice Check if `_user`'s lock by `_lockManager` can be unlocked
      * @param _user Owner of lock
      * @param _amount Amount of locked tokens to unlock
-     * @return Whether given lock of given owner can be unlocked by given sender
+     * @return Whether given user's lock can be unlocked
      */
     function canUnlock(address _user, uint256 _amount) external view returns (bool);
 }

--- a/packages/protocol/contracts/locking/ILockable.sol
+++ b/packages/protocol/contracts/locking/ILockable.sol
@@ -2,25 +2,25 @@ pragma solidity ^0.5.17;
 
 
 interface ILockable {
-    event NewLockManager(address indexed account, address indexed lockManager, bytes data);
-    event LockAmountChanged(address indexed account, address indexed lockManager, uint256 amount);
-    event LockAllowanceChanged(address indexed account, address indexed lockManager, uint256 allowance);
-    event LockManagerRemoved(address indexed account, address indexed lockManager);
-    event LockManagerTransferred(address indexed account, address indexed oldLockManager, address indexed newLockManager);
+    event NewLockManager(address indexed user, address indexed lockManager, bytes data);
+    event LockAmountChanged(address indexed user, address indexed lockManager, uint256 amount);
+    event LockAllowanceChanged(address indexed user, address indexed lockManager, uint256 allowance);
+    event LockManagerRemoved(address indexed user, address indexed lockManager);
+    event LockManagerTransferred(address indexed user, address indexed oldLockManager, address indexed newLockManager);
 
     function allowManager(address _lockManager, uint256 _allowance, bytes calldata _data) external;
-    function unlockAndRemoveManager(address _account, address _lockManager) external;
+    function unlockAndRemoveManager(address _user, address _lockManager) external;
     function increaseLockAllowance(address _lockManager, uint256 _allowance) external;
-    function decreaseLockAllowance(address _account, address _lockManager, uint256 _allowance) external;
+    function decreaseLockAllowance(address _user, address _lockManager, uint256 _allowance) external;
 
-    function lock(address _account, uint256 _amount) external;
-    function unlock(address _account, address _lockManager, uint256 _amount) external;
-    function slash(address _account, address _to, uint256 _amount) external;
-    function slashAndUnstake(address _account, address _to, uint256 _amount) external;
+    function lock(address _user, uint256 _amount) external;
+    function unlock(address _user, address _lockManager, uint256 _amount) external;
+    function slash(address _user, address _to, uint256 _amount) external;
+    function slashAndUnstake(address _user, address _to, uint256 _amount) external;
 
-    function getLock(address _account, address _lockManager) external view returns (uint256 _amount, uint256 _allowance);
-    function unlockedBalanceOf(address _account) external view returns (uint256);
-    function lockedBalanceOf(address _account) external view returns (uint256);
-    function getBalancesOf(address _account) external view returns (uint256 staked, uint256 locked);
-    function canUnlock(address _sender, address _account, address _lockManager, uint256 _amount) external view returns (bool);
+    function getLock(address _user, address _lockManager) external view returns (uint256 _amount, uint256 _allowance);
+    function unlockedBalanceOf(address _user) external view returns (uint256);
+    function lockedBalanceOf(address _user) external view returns (uint256);
+    function getBalancesOf(address _user) external view returns (uint256 staked, uint256 locked);
+    function canUnlock(address _sender, address _user, address _lockManager, uint256 _amount) external view returns (bool);
 }

--- a/packages/protocol/contracts/standards/IApproveAndCallFallBack.sol
+++ b/packages/protocol/contracts/standards/IApproveAndCallFallBack.sol
@@ -1,3 +1,5 @@
+// See MiniMe token (https://github.com/Giveth/minime/blob/master/contracts/MiniMeToken.sol)
+
 pragma solidity ^0.5.17;
 
 

--- a/packages/protocol/contracts/standards/IERC20.sol
+++ b/packages/protocol/contracts/standards/IERC20.sol
@@ -1,7 +1,7 @@
 // Brought from https://github.com/aragon/aragonOS/blob/v4.3.0/contracts/lib/token/ERC20.sol
-// Adapted to use pragma ^0.5.8 and satisfy our linter rules
+// Adapted to use pragma ^0.5.17 and satisfy our linter rules
 
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.17;
 
 
 /**

--- a/packages/protocol/contracts/standards/IERC900.sol
+++ b/packages/protocol/contracts/standards/IERC900.sol
@@ -14,8 +14,8 @@ interface IERC900 {
     function stake(uint256 _amount, bytes calldata _data) external;
 
     /**
-     * @dev Stake a certain amount of tokens in favor of someone
-     * @param _user Address to stake an amount of tokens to
+     * @dev Stake a certain amount of tokens to another address
+     * @param _user Address to stake tokens to
      * @param _amount Amount of tokens to be staked
      * @param _data Optional data that can be used to add signalling information in more complex staking applications
      */
@@ -29,27 +29,27 @@ interface IERC900 {
     function unstake(uint256 _amount, bytes calldata _data) external;
 
     /**
-     * @dev Tell the total amount of tokens staked for an address
-     * @param _addr Address querying the total amount of tokens staked for
-     * @return Total amount of tokens staked for an address
+     * @dev Tell the current total amount of tokens staked for an address
+     * @param _addr Address to query
+     * @return Current total amount of tokens staked for the address
      */
     function totalStakedFor(address _addr) external view returns (uint256);
 
     /**
-     * @dev Tell the total amount of tokens staked
-     * @return Total amount of tokens staked
+     * @dev Tell the current total amount of tokens staked from all addresses
+     * @return Current total amount of tokens staked from all addresses
      */
     function totalStaked() external view returns (uint256);
 
     /**
-     * @dev Tell the address of the token used for staking
-     * @return Address of the token used for staking
+     * @dev Tell the address of the staking token
+     * @return Address of the staking token
      */
     function token() external view returns (address);
 
     /*
-     * @dev Tell if the current registry supports historic information or not
-     * @return True if the optional history functions are implemented, false otherwise
+     * @dev Tell if the optional history functions are implemented
+     * @return True if the optional history functions are implemented
      */
     function supportsHistory() external pure returns (bool);
 }

--- a/packages/protocol/contracts/standards/IERC900History.sol
+++ b/packages/protocol/contracts/standards/IERC900History.sol
@@ -4,24 +4,24 @@ pragma solidity ^0.5.17;
 // Interface for ERC900: https://eips.ethereum.org/EIPS/eip-900, optional History methods
 interface IERC900History {
     /**
-     * @dev Get last time a user modified its staked balance
-     * @param _user Account requesting for
-     * @return Last block number when account's balance was modified
+     * @dev Tell last time a user modified their staked balance
+     * @param _user Address to query
+     * @return Last block number when address's balance was modified
      */
     function lastStakedFor(address _user) external view returns (uint256);
 
     /**
-     * @dev Get the total amount of tokens staked by a user at a given block number
-     * @param _user Account requesting for
-     * @param _blockNumber Block number at which we are requesting
-     * @return The amount of tokens staked by the account at the given block number
+     * @dev Tell the total amount of tokens staked for an address at a given block number
+     * @param _user Address to query
+     * @param _blockNumber Block number
+     * @return Total amount of tokens staked for the address at the given block number
      */
     function totalStakedForAt(address _user, uint256 _blockNumber) external view returns (uint256);
 
     /**
-     * @dev Get the total amount of tokens staked by all users at a given block number
-     * @param _blockNumber Block number at which we are requesting
-     * @return The amount of tokens staked at the given block number
+     * @dev Tell the total amount of tokens staked from all addresses at a given block number
+     * @param _blockNumber Block number
+     * @return Total amount of tokens staked from all addresses at the given block number
      */
     function totalStakedAt(uint256 _blockNumber) external view returns (uint256);
 }

--- a/packages/protocol/interfaces/ILockManager.sol
+++ b/packages/protocol/interfaces/ILockManager.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.4 <=0.7;
 
 interface ILockManager {
     /**
-     * @notice Check if `_user`'s by `_lockManager` can be unlocked
+     * @notice Check if `_user`'s lock by `_lockManager` can be unlocked
      * @param _user Owner of lock
      * @param _amount Amount of locked tokens to unlock
-     * @return Whether given lock of given owner can be unlocked by given sender
+     * @return Whether given user's lock can be unlocked
      */
     function canUnlock(address _user, uint256 _amount) external view returns (bool);
 }

--- a/packages/protocol/interfaces/IStaking.sol
+++ b/packages/protocol/interfaces/IStaking.sol
@@ -18,19 +18,19 @@ interface IStaking {
 
     // ILockable
     function allowManager(address _lockManager, uint256 _allowance, bytes _data) external;
-    function unlockAndRemoveManager(address _account, address _lockManager) external;
+    function unlockAndRemoveManager(address _user, address _lockManager) external;
     function increaseLockAllowance(address _lockManager, uint256 _allowance) external;
-    function decreaseLockAllowance(address _account, address _lockManager, uint256 _allowance) external;
-    function lock(address _account, uint256 _amount) external;
-    function unlock(address _account, address _lockManager, uint256 _amount) external;
-    function slash(address _account, address _to, uint256 _amount) external;
-    function slashAndUnstake(address _account, address _to, uint256 _amount) external;
+    function decreaseLockAllowance(address _user, address _lockManager, uint256 _allowance) external;
+    function lock(address _user, uint256 _amount) external;
+    function unlock(address _user, address _lockManager, uint256 _amount) external;
+    function slash(address _user, address _to, uint256 _amount) external;
+    function slashAndUnstake(address _user, address _to, uint256 _amount) external;
 
-    function getLock(address _account, address _lockManager) external view returns (uint256 _amount, uint256 _allowance);
-    function unlockedBalanceOf(address _account) external view returns (uint256);
+    function getLock(address _user, address _lockManager) external view returns (uint256 _amount, uint256 _allowance);
+    function unlockedBalanceOf(address _user) external view returns (uint256);
     function lockedBalanceOf(address _user) external view returns (uint256);
     function getBalancesOf(address _user) external view returns (uint256 staked, uint256 locked);
-    function canUnlock(address _sender, address _account, address _lockManager, uint256 _amount) external view returns (bool);
+    function canUnlock(address _sender, address _user, address _lockManager, uint256 _amount) external view returns (bool);
 
     // Misc.
     function transfer(address _to, uint256 _amount) external;

--- a/packages/protocol/interfaces/IStakingFactory.sol
+++ b/packages/protocol/interfaces/IStakingFactory.sol
@@ -4,7 +4,8 @@ import "./IStaking.sol";
 
 
 interface IStakingFactory {
+    function getOrCreateInstance(/* ERC20 */ address token) external returns (IStaking);
+
     function existsInstance(/* ERC20 */ address token) external view returns (bool);
     function getInstance(/* ERC20 */ address token) external view returns (IStaking);
-    function getOrCreateInstance(/* ERC20 */ address token) external returns (IStaking);
 }

--- a/packages/protocol/test/helpers/helpers.js
+++ b/packages/protocol/test/helpers/helpers.js
@@ -170,7 +170,7 @@ module.exports = (artifacts) => {
       users.map(async (user) => await Promise.all(
         managers.map(async (manager) => {
           const lock = await staking.getLock(user.address, manager)
-          assert.isTrue(lock._amount.lte(lock._allowance))
+          assert.isTrue(lock.amount.lte(lock.allowance))
         })
       ))
     )
@@ -194,7 +194,7 @@ module.exports = (artifacts) => {
       users.map(async (user) => await Promise.all(
         managers.map(async (manager) => {
           const lock = await staking.getLock(user.address, manager)
-          const errorMessage = lock._allowance.gt(bn(0)) ? STAKING_ERRORS.ERROR_NOT_ENOUGH_LOCK : STAKING_ERRORS.ERROR_LOCK_DOES_NOT_EXIST
+          const errorMessage = lock.allowance.gt(bn(0)) ? STAKING_ERRORS.ERROR_NOT_ENOUGH_LOCK : STAKING_ERRORS.ERROR_LOCK_DOES_NOT_EXIST
           await assertRevert(
             staking.unlock(user.address, manager, user.lockedBalance.add(bn(1)), { from: user.address }),
             errorMessage

--- a/packages/protocol/test/locking/locking.js
+++ b/packages/protocol/test/locking/locking.js
@@ -19,9 +19,9 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
     await approveStakeAndLock({ staking, manager: user1, from: owner })
 
     // check lock values
-    const { _amount, _allowance } = await staking.getLock(owner, user1)
-    assertBn(_amount, DEFAULT_LOCK_AMOUNT, "locked amount should match")
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT, "locked allowance should match")
+    const { amount, allowance } = await staking.getLock(owner, user1)
+    assertBn(amount, DEFAULT_LOCK_AMOUNT, "locked amount should match")
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT, "locked allowance should match")
 
     assertBn(await staking.unlockedBalanceOf(owner), DEFAULT_STAKE_AMOUNT.sub(DEFAULT_LOCK_AMOUNT), "Unlocked balance should match")
     const { staked, locked } = await staking.getBalancesOf(owner)
@@ -63,8 +63,8 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
   it('creates a new allowance', async () => {
     await staking.allowManager(user1, DEFAULT_LOCK_AMOUNT, EMPTY_DATA)
 
-    const { _allowance  } = await staking.getLock(owner, user1)
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
+    const { allowance  } = await staking.getLock(owner, user1)
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
   })
 
   it('creates a new allowance and then lock manager locks', async () => {
@@ -73,9 +73,9 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
     await staking.lock(owner, DEFAULT_LOCK_AMOUNT, { from: user1 })
 
     // check lock values
-    const { _amount, _allowance } = await staking.getLock(owner, user1)
-    assertBn(_amount, DEFAULT_LOCK_AMOUNT, "locked amount should match")
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT, "locked allowance should match")
+    const { amount, allowance } = await staking.getLock(owner, user1)
+    assertBn(amount, DEFAULT_LOCK_AMOUNT, "locked amount should match")
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT, "locked allowance should match")
 
     assertBn(await staking.unlockedBalanceOf(owner), DEFAULT_STAKE_AMOUNT.sub(DEFAULT_LOCK_AMOUNT), "Unlocked balance should match")
   })
@@ -94,8 +94,8 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
 
     await staking.increaseLockAllowance(user1, DEFAULT_LOCK_AMOUNT)
 
-    const { _allowance } = await staking.getLock(owner, user1)
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT.mul(bn(2)), "allowed amount should match")
+    const { allowance } = await staking.getLock(owner, user1)
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT.mul(bn(2)), "allowed amount should match")
   })
 
   it('fails increasing allowance of non-existing', async () => {
@@ -121,8 +121,8 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
 
     await staking.decreaseLockAllowance(owner, user1, 1, { from: owner })
 
-    const { _allowance } = await staking.getLock(owner, user1)
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
+    const { allowance } = await staking.getLock(owner, user1)
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
   })
 
   it('decreases allowance of existing lock by manager', async () => {
@@ -132,8 +132,8 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
 
     await staking.decreaseLockAllowance(owner, user1, 1, { from: user1 })
 
-    const { _allowance } = await staking.getLock(owner, user1)
-    assertBn(_allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
+    const { allowance } = await staking.getLock(owner, user1)
+    assertBn(allowance, DEFAULT_LOCK_AMOUNT, "allowed amount should match")
   })
 
   it('fails decreasing allowance of existing lock by 0', async () => {
@@ -173,8 +173,8 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
     await staking.increaseLockAllowance(user1, DEFAULT_LOCK_AMOUNT)
     await staking.lock(owner, DEFAULT_LOCK_AMOUNT, { from: user1 })
 
-    const { _amount } = await staking.getLock(owner, user1)
-    assertBn(_amount, DEFAULT_LOCK_AMOUNT.mul(bn(2)), "locked amount should match")
+    const { amount } = await staking.getLock(owner, user1)
+    assertBn(amount, DEFAULT_LOCK_AMOUNT.mul(bn(2)), "locked amount should match")
   })
 
   it('fails increasing lock with 0 tokens', async () => {
@@ -338,7 +338,7 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
 
   it('change lock amount', async () => {
     await approveStakeAndLock({ staking, manager: lockManager, from: owner })
-    const { _amount: amount1 } = await staking.getLock(owner, lockManager.address)
+    const { amount: amount1 } = await staking.getLock(owner, lockManager.address)
     assertBn(amount1, bn(DEFAULT_LOCK_AMOUNT), "Amount should match")
     assertBn(await staking.unlockedBalanceOf(owner), DEFAULT_STAKE_AMOUNT.sub(DEFAULT_LOCK_AMOUNT), "Unlocked balance should match")
 
@@ -346,7 +346,7 @@ contract('Staking app, Locking', ([owner, user1, user2]) => {
     const unlockAmount = DEFAULT_LOCK_AMOUNT.div(bn(2))
     await lockManager.unlock(staking.address, owner, unlockAmount)
 
-    const { _amount: amount2 } = await staking.getLock(owner, lockManager.address)
+    const { amount: amount2 } = await staking.getLock(owner, lockManager.address)
     assertBn(amount2, unlockAmount, "Amount should match")
     assertBn(await staking.unlockedBalanceOf(owner), DEFAULT_STAKE_AMOUNT.sub(unlockAmount), "Unlocked balance should match")
   })

--- a/packages/protocol/test/transfers.js
+++ b/packages/protocol/test/transfers.js
@@ -83,7 +83,7 @@ contract('Staking app, Transferring', ([owner, user1, user2]) => {
         assertBn(await staking.totalStaked(), totalStaked, "Total stake should match")
 
         // check lock values
-        const { _amount: amount, _data: data }  = await staking.getLock(owner, lockManager.address)
+        const { amount, data }  = await staking.getLock(owner, lockManager.address)
         assertBn(amount, DEFAULT_LOCK_AMOUNT.sub(transferAmount), "locked amount should match")
       })
 
@@ -103,7 +103,7 @@ contract('Staking app, Transferring', ([owner, user1, user2]) => {
         assertBn(await staking.totalStaked(), totalStaked, "Total stake should match")
 
         // check lock values
-        const { _amount: amount, _data: data }  = await staking.getLock(owner, lockManager.address)
+        const { amount: amount, data: data }  = await staking.getLock(owner, lockManager.address)
         assertBn(amount, bn(0), "locked amount should match")
       })
 


### PR DESCRIPTION
Easiest to review commit by commit.

The only "breaking" change is in d9faa09, where the concept of `account` in `ILockable`'s external interfaces is replaced by `user`, to align with the rest of Staking.